### PR TITLE
Add env placeholders and document vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Telepass Backend
+
+This project uses Spring Boot. Sensitive configuration values are provided via environment variables.
+
+## Required environment variables
+
+| Variable | Description |
+| -------- | ----------- |
+| `MAIL_USERNAME` | Username for sending email via SMTP |
+| `MAIL_PASSWORD` | Password or app token for the SMTP user |
+| `DB_USERNAME`   | Database username for the Postgres datasource |
+| `DB_PASSWORD`   | Database password for the Postgres datasource |
+
+These variables can be exported in your shell or provided in a `.env` file that Spring Boot reads using the standard property placeholders.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: gosellingproject@gmail.com
-    password: mmlrtnqtokjctfgx
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
     properties:
       mail:
         transport:
@@ -26,8 +26,8 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
-    password: postgres
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## Summary
- replace hardcoded passwords in application.yml with placeholders
- document environment variables for mail and database credentials

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68442f5a8368833281338da7856f0bcb