### PR TITLE
Configure telegram token property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Telepass Backend
+
+## Configuration
+
+The application reads the Telegram bot token from the `telegram.bot-token` property.
+Provide this value via the environment variable `TELEGRAM_BOT_TOKEN` referenced in
+`src/main/resources/application.yml`.
+
+Example:
+
+```bash
+export TELEGRAM_BOT_TOKEN=<your-token>
+```
+

--- a/src/main/java/com/example/tb/authentication/service/telegram/TelegramServiceImpl.java
+++ b/src/main/java/com/example/tb/authentication/service/telegram/TelegramServiceImpl.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestTemplate;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.meta.api.methods.GetFile;
@@ -47,13 +48,14 @@ import com.google.zxing.common.HybridBinarizer;
 @Service
 public class TelegramServiceImpl extends TelegramLongPollingBot {
     private static final Logger logger = LoggerFactory.getLogger(TelegramServiceImpl.class);
-    public static final String botToken = "7604740715:AAGnrNxu0hnnJ8JdtEBin1R3S_yE6GiHGHI";
+    private final String botToken;
     public static final String botUsername = "telepasskhbot";
     private static final long ADMIN_CHAT_ID = 649084122;
     private boolean awaitingQrUpload = false;
 
-    public TelegramServiceImpl() {
+    public TelegramServiceImpl(@Value("${telegram.bot-token}") String botToken) {
         super(botToken);
+        this.botToken = botToken;
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,5 @@ myAdmin:
   password: Telepass1@
 BaseUrl: http://localhost:8080/
 WebBaseUrl: http://localhost:3000/
+telegram:
+  bot-token: ${TELEGRAM_BOT_TOKEN}


### PR DESCRIPTION
## Summary
- inject `telegram.bot-token` into `TelegramServiceImpl`
- configure token in `application.yml`
- document the new property

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_b_68442f5cb93c8332aa0eeef1e15d6710