### PR TITLE
Fix manifest main class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ tasks.named('test') {
 jar {
     manifest {
         attributes(
-                'Main-Class': 'com.example.telegram_api.TbApiApplication'
+                'Main-Class': 'com.example.tb.TbApplication'
         )
     }
 }


### PR DESCRIPTION
## Summary
- update `build.gradle` to use `com.example.tb.TbApplication` as the main class

## Testing
- `./gradlew bootJar` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68442f5e205083329cc60d29a3a72a5f