### PR TITLE
Add setup instructions and environment sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,9 @@
+# Copy this file to .env and fill in the values
+MAIL_USERNAME=your_email@example.com
+MAIL_PASSWORD=your_email_password
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
+BASE_URL=http://localhost:8080/
+WEB_BASE_URL=http://localhost:3000/

--- a/README.md
+++ b/README.md
@@ -16,3 +16,26 @@ This project uses Spring Boot. Sensitive configuration values are provided via e
 | `WEB_BASE_URL`  | URL for the frontend to redirect after verification |
 
 These variables can be exported in your shell or provided in a `.env` file that Spring Boot reads using the standard property placeholders.
+
+## Quick start
+
+1. Copy `.env.sample` to `.env` and update the values as needed.
+
+```bash
+cp .env.sample .env
+```
+
+2. Start a local PostgreSQL instance using Docker Compose:
+
+```bash
+docker compose up -d db
+```
+
+This exposes Postgres on `localhost:5432` with credentials taken from the
+`DB_USERNAME` and `DB_PASSWORD` values in your `.env` file.
+
+3. Build and run the application:
+
+```bash
+./gradlew bootRun
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:13
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- provide `.env.sample` for required variables
- add docker-compose with a Postgres service for local development
- document how to start the database and run the app in the README

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68446634f78083329b45dd037472eb94