### PR TITLE
Add Google Authenticator support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail:3.1.1'
     implementation 'com.google.zxing:core:3.5.2'
     implementation 'com.google.zxing:javase:3.5.2'
+    implementation 'com.warrenstrange:googleauth:1.6.0'
     implementation 'org.postgresql:postgresql'
     implementation 'com.google.zxing:core:3.5.2'
     implementation 'com.google.zxing:javase:3.5.2'

--- a/src/main/java/com/example/tb/authentication/controller/AdminController.java
+++ b/src/main/java/com/example/tb/authentication/controller/AdminController.java
@@ -27,13 +27,13 @@ import com.example.tb.authentication.auth.InfoChangePassword;
 import com.example.tb.authentication.repository.admin.AdminRepository;
 import com.example.tb.authentication.service.admin.AdminService;
 import com.example.tb.authentication.service.otp.OtpService;
+import com.example.tb.model.response.ApiResponse;
 import com.example.tb.jwt.JwtResponse;
 import com.example.tb.jwt.JwtTokenUtils;
 import com.example.tb.model.entity.Admin;
 import com.example.tb.model.request.AdminRequest;
 import com.example.tb.model.request.OtpRequest;
 import com.example.tb.model.request.OtpRequestEmail;
-import com.example.tb.model.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -117,6 +117,25 @@ public class AdminController {
         return ApiResponse.builder()
                 .date(LocalDateTime.now())
                 .message("OTP via email sent successfully\"")
+                .build();
+    }
+
+    @PostMapping("/ga-secret")
+    public ApiResponse<?> generateGoogleSecret(@RequestParam String username) {
+        String secret = adminService.generateGoogleSecret(username);
+        return ApiResponse.builder()
+                .date(LocalDateTime.now())
+                .message("Google Authenticator secret generated")
+                .payload(secret)
+                .build();
+    }
+
+    @PostMapping("/ga-verify")
+    public ApiResponse<?> verifyGoogleCode(@RequestParam String username, @RequestParam int code) {
+        boolean valid = adminService.verifyGoogleCode(username, code);
+        return ApiResponse.builder()
+                .date(LocalDateTime.now())
+                .message(valid ? "Code verified" : "Invalid code")
                 .build();
     }
 

--- a/src/main/java/com/example/tb/authentication/service/admin/AdminService.java
+++ b/src/main/java/com/example/tb/authentication/service/admin/AdminService.java
@@ -18,4 +18,8 @@ public interface AdminService extends UserDetailsService {
     void sendEmail(String email, String name, String msg) throws MessagingException, UnsupportedEncodingException;
     boolean verifyEmailToken(String token);
 
+    String generateGoogleSecret(String username);
+
+    boolean verifyGoogleCode(String username, int code);
+
 }

--- a/src/main/java/com/example/tb/authentication/service/google/GoogleAuthService.java
+++ b/src/main/java/com/example/tb/authentication/service/google/GoogleAuthService.java
@@ -1,0 +1,19 @@
+package com.example.tb.authentication.service.google;
+
+import com.warrenstrange.googleauth.GoogleAuthenticator;
+import com.warrenstrange.googleauth.GoogleAuthenticatorKey;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GoogleAuthService {
+    private final GoogleAuthenticator googleAuthenticator = new GoogleAuthenticator();
+
+    public String generateSecret() {
+        GoogleAuthenticatorKey key = googleAuthenticator.createCredentials();
+        return key.getKey();
+    }
+
+    public boolean verifyCode(String secret, int code) {
+        return googleAuthenticator.authorize(secret, code);
+    }
+}

--- a/src/main/java/com/example/tb/model/entity/Admin.java
+++ b/src/main/java/com/example/tb/model/entity/Admin.java
@@ -47,6 +47,9 @@ public class Admin implements UserDetails {
     @Column(length = 1000)
     private String profile;
 
+    @Column(name = "google_secret")
+    private String googleSecret;
+
     @Override
     public String getUsername() {
         return username;


### PR DESCRIPTION
## Summary
- add Google Authenticator library dependency
- store Google secret for admin users
- service methods and endpoints to generate/verify Google Auth codes

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68452043a2e083329d23f4404eb62031